### PR TITLE
fix: avoid p in p

### DIFF
--- a/src/components/PostPreview.vue
+++ b/src/components/PostPreview.vue
@@ -14,7 +14,7 @@
       </saber-link>
     </h2>
 
-    <p class="mb-4 mt-0" v-html="post.attributes.excerpt" />
+    <div class="mb-4 mt-0" v-html="post.attributes.excerpt"></div>
 
     <saber-link
       :to="post.attributes.permalink"

--- a/src/layouts/home.vue
+++ b/src/layouts/home.vue
@@ -23,7 +23,7 @@
           </saber-link>
         </h2>
 
-        <p class="mt-0 mb-4" v-html="post.attributes.excerpt" />
+        <div class="mt-0 mb-4" v-html="post.attributes.excerpt"></div>
 
         <saber-link
           :to="post.attributes.permalink"


### PR DESCRIPTION
`post.attributes.excerpt` already contains `<p>` (or other block-level elements), you can't nest block-level elements in `<p>`